### PR TITLE
Init actors only if hosting non zero actors

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -343,9 +343,11 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 	a.daprHTTPAPI.SetDirectMessaging(a.directMessaging)
 	grpcAPI.SetDirectMessaging(a.directMessaging)
 
-	err = a.initActors()
-	if err != nil {
+	if a.hostingActors() {
+	    err = a.initActors()
+	    if err != nil {
 		log.Warnf("failed to init actors: %s", err)
+	    }
 	}
 
 	a.daprHTTPAPI.SetActorRuntime(a.actor)


### PR DESCRIPTION
Placement service is optional for dapr usage. It is required only if Actors are being used. But, in current implementation actors are initialized anyways making placement servers mandatory.  This PR fixes this issue by initializing actors only if at least one actor is being hosted.