### PR TITLE
Dapr changes for IPv6

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -7,6 +7,7 @@ package http
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -69,7 +70,12 @@ func (s *server) StartNonBlocking() {
 	}
 
 	go func() {
-		log.Fatal(customServer.ListenAndServe(fmt.Sprintf(":%v", s.config.Port)))
+		// Use net.Listen to bind to IPv6 on dual-stack systems (consistent with gRPC servers)
+		lis, err := net.Listen("tcp", fmt.Sprintf(":%v", s.config.Port))
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Fatal(customServer.Serve(lis))
 	}()
 
 	if s.config.EnableProfiling {


### PR DESCRIPTION
This pull request updates the HTTP server startup logic to improve compatibility with IPv6 and dual-stack systems. The most important change is switching from `ListenAndServe` to explicitly using `net.Listen`, which aligns the HTTP server's behavior with that of gRPC servers and ensures consistent network binding.

**Networking improvements:**

* Updated `StartNonBlocking` in `server.go` to use `net.Listen` for binding to the server port, enabling better support for IPv6 and dual-stack environments.
* Added an import of the `net` package to support the above changes.