### PR TITLE
updated the v1.16.6-ib with custom changes in v1.0.0-ib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+@Library('jenkins.shared.library') _
+
+pipeline {
+  agent {
+    label 'ubuntu_docker_label'
+  }
+  tools {
+    go "Go 1.24"
+  }
+  options {
+    checkoutToSubdirectory('src/github.com/infobloxopen/dapr')
+  }
+  environment {
+    GOPATH = "$WORKSPACE"
+    DIRECTORY = "src/github.com/infobloxopen/dapr"
+    DOCKER_IMAGE = "infoblox/dapr"
+  }
+  stages {
+    stage("Setup") {
+      steps {
+        prepareBuild()
+      }
+    }
+    stage("Test") {
+      steps {
+        sh "cd $DIRECTORY && make test"
+      }
+    }
+    stage("build-and-archive-binaries-linux-amd64") {
+      steps {
+        sh "cd $DIRECTORY && make tidy && make release GOOS='linux' GOARCH='amd64'"
+      }
+    }
+    stage("Build-And-Push-Docker") {
+      steps {
+        withDockerRegistry([credentialsId: "dockerhub-bloxcicd", url: ""]) {
+          sh "cd $DIRECTORY && make docker-push GOOS='linux' GOARCH='amd64'"
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      sh "cd $DIRECTORY && make clean GOOS='linux' GOARCH='amd64'"
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,9 @@ pipeline {
     }
   }
   post {
+    success {
+      finalizeBuild(sh(script: 'cd $DIRECTORY && make show-images', returnStdout: true))
+    }
     cleanup {
       sh "cd $DIRECTORY && make clean GOOS='linux' GOARCH='amd64'"
     }

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,13 @@ PROTOBUF_SUITE_VERSION = 25.4
 
 # name of protoc-gen-go when protoc-gen-go --version is run.
 PROTOC_GEN_GO_NAME = "protoc-gen-go"
-ifdef REL_VERSION
-	DAPR_VERSION := $(REL_VERSION)
-else
-	DAPR_VERSION := edge
-endif
+
+GIT_COMMIT_NUMBER = $(shell git rev-parse --short HEAD)
+DAPR_VERSION = v1.16.6-ib-$(GIT_COMMIT_NUMBER)
+DAPR_REGISTRY ?= infoblox
+DAPR_TAG ?= $(DAPR_VERSION)
+TARGET_OS ?= linux
+TARGET_ARCH ?= amd64
 
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)
@@ -595,3 +597,68 @@ include docker/docker.mk
 # Target: tests                                                                #
 ################################################################################
 include tests/dapr_tests.mk
+
+
+# release target: build and archive
+.PHONY: release
+release: build archive
+
+# tidy target for go mod tidy
+.PHONY: tidy
+tidy:
+	go mod tidy
+
+# clean target for docker images
+.PHONY: clean
+clean:
+	-$(DOCKER) rmi -f $$(docker images -q $(DAPR_REGISTRY)/dapr:$(DAPR_TAG)) 2>/dev/null || true
+	-$(DOCKER) rmi -f $$(docker images -q $(DAPR_REGISTRY)/daprd:$(DAPR_TAG)) 2>/dev/null || true
+	-$(DOCKER) rmi -f $$(docker images -q $(DAPR_REGISTRY)/placement:$(DAPR_TAG)) 2>/dev/null || true
+	-$(DOCKER) rmi -f $$(docker images -q $(DAPR_REGISTRY)/sentry:$(DAPR_TAG)) 2>/dev/null || true
+	-$(DOCKER) rmi -f $$(docker images -q $(DAPR_REGISTRY)/operator:$(DAPR_TAG)) 2>/dev/null || true
+	-$(DOCKER) rmi -f $$(docker images -q $(DAPR_REGISTRY)/injector:$(DAPR_TAG)) 2>/dev/null || true
+	-$(DOCKER) rmi -f $$(docker images -q $(DAPR_REGISTRY)/scheduler:$(DAPR_TAG)) 2>/dev/null || true
+
+################################################################################
+# Target: dev-docker-build, dev-docker-push                                    #
+# Build and push images to Harbor dev registry                                 #
+################################################################################
+DEV_REGISTRY ?= harbor.services.sdp.infoblox.com/infobloxcto-dev
+DEV_TAG ?= $(DAPR_VERSION)
+DEV_TARGET_ARCH ?= amd64
+DEV_BIN_PATH = $(OUT_DIR)/linux_$(DEV_TARGET_ARCH)/release
+
+# Dev build linux binaries for target architecture (default: amd64)
+.PHONY: dev-build-linux
+dev-build-linux:
+	$(info Building linux binaries for $(DEV_TARGET_ARCH)...)
+	CGO_ENABLED=$(CGO) GOOS=linux GOARCH=$(DEV_TARGET_ARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -tags=$(DAPR_GO_BUILD_TAGS) -o $(DEV_BIN_PATH)/daprd ./cmd/daprd/
+	CGO_ENABLED=$(CGO) GOOS=linux GOARCH=$(DEV_TARGET_ARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -tags=$(DAPR_GO_BUILD_TAGS) -o $(DEV_BIN_PATH)/placement ./cmd/placement/
+	CGO_ENABLED=$(CGO) GOOS=linux GOARCH=$(DEV_TARGET_ARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -tags=$(DAPR_GO_BUILD_TAGS) -o $(DEV_BIN_PATH)/operator ./cmd/operator/
+	CGO_ENABLED=$(CGO) GOOS=linux GOARCH=$(DEV_TARGET_ARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -tags=$(DAPR_GO_BUILD_TAGS) -o $(DEV_BIN_PATH)/injector ./cmd/injector/
+	CGO_ENABLED=$(CGO) GOOS=linux GOARCH=$(DEV_TARGET_ARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -tags=$(DAPR_GO_BUILD_TAGS) -o $(DEV_BIN_PATH)/sentry ./cmd/sentry/
+	CGO_ENABLED=$(CGO) GOOS=linux GOARCH=$(DEV_TARGET_ARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -tags=$(DAPR_GO_BUILD_TAGS) -o $(DEV_BIN_PATH)/scheduler ./cmd/scheduler/
+
+# Dev docker build - builds amd64 images for Harbor dev registry
+.PHONY: dev-docker-build
+dev-docker-build: dev-build-linux
+	$(info Building dev images for $(DEV_REGISTRY) (linux/$(DEV_TARGET_ARCH))...)
+	$(DOCKER) build --platform linux/$(DEV_TARGET_ARCH) --output type=docker --build-arg PKG_FILES=* -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(DEV_BIN_PATH) -t $(DEV_REGISTRY)/dapr-dapr:$(DEV_TAG)
+	$(DOCKER) build --platform linux/$(DEV_TARGET_ARCH) --output type=docker --build-arg PKG_FILES=daprd -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(DEV_BIN_PATH) -t $(DEV_REGISTRY)/dapr-daprd:$(DEV_TAG)
+	$(DOCKER) build --platform linux/$(DEV_TARGET_ARCH) --output type=docker --build-arg PKG_FILES=placement -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(DEV_BIN_PATH) -t $(DEV_REGISTRY)/dapr-placement:$(DEV_TAG)
+	$(DOCKER) build --platform linux/$(DEV_TARGET_ARCH) --output type=docker --build-arg PKG_FILES=sentry -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(DEV_BIN_PATH) -t $(DEV_REGISTRY)/dapr-sentry:$(DEV_TAG)
+	$(DOCKER) build --platform linux/$(DEV_TARGET_ARCH) --output type=docker --build-arg PKG_FILES=operator -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(DEV_BIN_PATH) -t $(DEV_REGISTRY)/dapr-operator:$(DEV_TAG)
+	$(DOCKER) build --platform linux/$(DEV_TARGET_ARCH) --output type=docker --build-arg PKG_FILES=injector -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(DEV_BIN_PATH) -t $(DEV_REGISTRY)/dapr-injector:$(DEV_TAG)
+	$(DOCKER) build --platform linux/$(DEV_TARGET_ARCH) --output type=docker --build-arg PKG_FILES=scheduler -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(DEV_BIN_PATH) -t $(DEV_REGISTRY)/dapr-scheduler:$(DEV_TAG)
+
+# Dev docker push - pushes images to Harbor dev registry
+.PHONY: dev-docker-push
+dev-docker-push: dev-docker-build
+	$(info Pushing dev images to $(DEV_REGISTRY)...)
+	$(DOCKER) push $(DEV_REGISTRY)/dapr-dapr:$(DEV_TAG)
+	$(DOCKER) push $(DEV_REGISTRY)/dapr-daprd:$(DEV_TAG)
+	$(DOCKER) push $(DEV_REGISTRY)/dapr-placement:$(DEV_TAG)
+	$(DOCKER) push $(DEV_REGISTRY)/dapr-sentry:$(DEV_TAG)
+	$(DOCKER) push $(DEV_REGISTRY)/dapr-operator:$(DEV_TAG)
+	$(DOCKER) push $(DEV_REGISTRY)/dapr-injector:$(DEV_TAG)
+	$(DOCKER) push $(DEV_REGISTRY)/dapr-scheduler:$(DEV_TAG)

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -170,6 +170,9 @@ spec:
 {{- if .Values.global.argoRolloutServiceReconciler.enabled }}
         - "--enable-argo-rollout-service-reconciler"
 {{- end }}
+{{- if .Values.disableLeaderElection }}
+        - "--disable-leader-election"
+{{- end }}
 {{- if .Values.global.operator.watchdogCanPatchPodLabels }}
         - "--watchdog-can-patch-pod-labels"
 {{- end }}

--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -5,11 +5,14 @@ watchNamespace: ""
 maxPodRestartsPerMinute: 20
 component: operator
 
+# Set to true to disable leader election (useful for single-replica operator deployments)
+disableLeaderElection: false
+
 # Override this to use a custom operator service image.
 # If the image name contains a "/", it is assumed to be a full docker image name, including the registry url and tag.
 # Otherwise, the helm chart will use {{ .Values.global.registry }}/{{ .Values.image.name }}:{{ .Values.global.tag }}
 image:
-  name: "operator"
+  name: "dapr-operator"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/dapr/charts/dapr_placement/values.yaml
+++ b/charts/dapr/charts/dapr_placement/values.yaml
@@ -5,7 +5,7 @@ component: placement
 # If the image name contains a "/", it is assumed to be a full docker image name, including the registry url and tag.
 # Otherwise, the helm chart will use {{ .Values.global.registry }}/{{ .Values.image.name }}:{{ .Values.global.tag }}
 image:
-  name: "placement"
+  name: "dapr-placement"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if (eq .Values.global.scheduler.enabled true) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -284,4 +285,5 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName:
 {{ toYaml .Values.global.priorityClassName | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/dapr/charts/dapr_scheduler/values.yaml
+++ b/charts/dapr/charts/dapr_scheduler/values.yaml
@@ -9,7 +9,7 @@ component: scheduler
 # If the image name contains a "/", it is assumed to be a full docker image name, including the registry url and tag.
 # Otherwise, the helm chart will use {{ .Values.global.registry }}/{{ .Values.image.name }}:{{ .Values.global.tag }}
 image:
-  name: "scheduler"
+  name: "dapr-scheduler"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/dapr/charts/dapr_sentry/values.yaml
+++ b/charts/dapr/charts/dapr_sentry/values.yaml
@@ -6,7 +6,7 @@ component: sentry
 # If the image name contains a "/", it is assumed to be a full docker image name, including the registry url and tag.
 # Otherwise, the helm chart will use {{ .Values.global.registry }}/{{ .Values.image.name }}:{{ .Values.global.tag }}
 image:
-  name: "sentry"
+  name: "dapr-sentry"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -182,6 +182,10 @@ spec:
           value: {{ .Values.ignoreEntrypointTolerations | toYaml }}
 {{- end }}
 
+        # Configuration for scheduler
+        - name: SCHEDULER_ENABLED
+          value: {{ .Values.global.scheduler.enabled | toString | toYaml }}
+
         # Configuration for actors and reminders
         - name: ACTORS_ENABLED
           value: {{ .Values.global.actors.enabled | toString | toYaml }}

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -7,13 +7,13 @@ component: sidecar-injector
 # If the image name contains a "/", it is assumed to be a full docker image name, including the registry url and tag.
 # Otherwise, the helm chart will use {{ .Values.global.registry }}/{{ .Values.image.name }}:{{ .Values.global.tag }}
 image:
-  name: "daprd"
+  name: "dapr-daprd"
 
 # Override this to use a custom injector service image.
 # If the image name contains a "/", it is assumed to be a full docker image name, including the registry url and tag.
 # Otherwise, the helm chart will use {{ .Values.global.registry }}/{{ .Values.injectorImage.name }}:{{ .Values.global.tag }}
 injectorImage:
-  name: "injector"
+  name: "dapr-injector"
 
 deploymentAnnotations: {}
 
@@ -34,7 +34,7 @@ allowedServiceAccounts: ""
 allowedServiceAccountsPrefixNames: ""
 resources: {}
 kubeClusterDomain: cluster.local
-ignoreEntrypointTolerations: "[{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"alibabacloud.com/eci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"azure.com/aci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"aws\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"huawei.com/cci\\\"}]"
+ignoreEntrypointTolerations: '[{"effect":"NoSchedule","key":"alibabacloud.com/eci"},{"effect":"NoSchedule","key":"azure.com/aci"},{"effect":"NoSchedule","key":"aws"},{"effect":"NoSchedule","key":"huawei.com/cci"}]'
 hostNetwork: false
 healthzPort: 8080
 objectSelector: {}

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -104,12 +104,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # check the required environment variables
 check-docker-env:
-ifeq ($(DAPR_REGISTRY),)
-	$(error DAPR_REGISTRY environment variable must be set)
-endif
-ifeq ($(DAPR_TAG),)
-	$(error DAPR_TAG environment variable must be set)
-endif
+        @echo "Using DAPR_REGISTRY=$(DAPR_REGISTRY) DAPR_TAG=$(DAPR_TAG)"
 
 check-arch:
 ifeq ($(TARGET_OS),)

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -26,6 +26,39 @@ import (
 	kitstrings "github.com/dapr/kit/strings"
 )
 
+// Infoblox legacy annotation keys for backward compatibility
+const (
+	infobloxSidecarGRPCPort         = "com.infoblox.dapr.sidecar-grpc-port"
+	infobloxSidecarHTTPPort         = "com.infoblox.dapr.sidecar-http-port"
+	infobloxSidecarInternalGRPCPort = "com.infoblox.dapr.sidecar-internal-grpc-port"
+)
+
+// mapLegacyInfobloxAnnotations copies legacy Infoblox annotations to standard Dapr annotations
+// if the standard annotations are not already set. This provides backward compatibility
+// for applications migrating from v1.0.0-ib.
+func mapLegacyInfobloxAnnotations(an map[string]string) map[string]string {
+	if an == nil {
+		return an
+	}
+
+	// Map legacy Infoblox annotations to standard Dapr annotations (if not already set)
+	legacyMappings := map[string]string{
+		infobloxSidecarGRPCPort:         "dapr.io/grpc-port",
+		infobloxSidecarHTTPPort:         "dapr.io/http-port",
+		infobloxSidecarInternalGRPCPort: "dapr.io/internal-grpc-port",
+	}
+
+	for legacyKey, standardKey := range legacyMappings {
+		if legacyVal, hasLegacy := an[legacyKey]; hasLegacy {
+			if _, hasStandard := an[standardKey]; !hasStandard {
+				an[standardKey] = legacyVal
+			}
+		}
+	}
+
+	return an
+}
+
 // GetInjectedComponentContainersFn is a function that returns the list of component containers for a given appID and namespace.
 type GetInjectedComponentContainersFn = func(appID string, namespace string) ([]corev1.Container, error)
 
@@ -136,7 +169,9 @@ func NewSidecarConfig(pod *corev1.Pod) *SidecarConfig {
 }
 
 func (c *SidecarConfig) SetFromPodAnnotations() {
-	c.setFromAnnotations(c.pod.Annotations)
+	// INFOBLOX: Map legacy annotations for backward compatibility
+	annotations := mapLegacyInfobloxAnnotations(c.pod.Annotations)
+	c.setFromAnnotations(annotations)
 }
 
 func (c *SidecarConfig) setDefaultValues() {

--- a/pkg/injector/service/config.go
+++ b/pkg/injector/service/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	TrustAnchorsFile        string `envconfig:"DAPR_TRUST_ANCHORS_FILE"`
 	ControlPlaneTrustDomain string `envconfig:"DAPR_CONTROL_PLANE_TRUST_DOMAIN"`
 	SentryAddress           string `envconfig:"DAPR_SENTRY_ADDRESS"`
+	SchedulerEnabled        bool   `envconfig:"SCHEDULER_ENABLED" default:"true"`
 
 	parsedActorsEnabled              bool
 	parsedActorsService              patcher.Service

--- a/pkg/injector/service/injector.go
+++ b/pkg/injector/service/injector.go
@@ -234,29 +234,34 @@ func (i *injector) Run(ctx context.Context, tlsConfig *tls.Config, sentryID spif
 	i.currentTrustAnchors = currentTrustAnchors
 	i.sentrySPIFFEID = sentryID
 
-	for {
-		var sched *appsv1.StatefulSet
-		sched, err := i.kubeClient.AppsV1().StatefulSets(i.controlPlaneNamespace).Get(ctx, "dapr-scheduler-server", metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			log.Warnf("%s/dapr-scheduler-server StatefulSet not found, retrying in 5 seconds", i.controlPlaneNamespace)
-			select {
-			case <-time.After(5 * time.Second):
-				continue
-			case <-ctx.Done():
-				return fmt.Errorf("%s/dapr-scheduler-server StatefulSet not found", i.controlPlaneNamespace)
+	if i.config.SchedulerEnabled {
+		for {
+			var sched *appsv1.StatefulSet
+			sched, err := i.kubeClient.AppsV1().StatefulSets(i.controlPlaneNamespace).Get(ctx, "dapr-scheduler-server", metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				log.Warnf("%s/dapr-scheduler-server StatefulSet not found, retrying in 5 seconds", i.controlPlaneNamespace)
+				select {
+				case <-time.After(5 * time.Second):
+					continue
+				case <-ctx.Done():
+					return fmt.Errorf("%s/dapr-scheduler-server StatefulSet not found", i.controlPlaneNamespace)
+				}
 			}
-		}
 
-		if err != nil {
-			return fmt.Errorf("error getting dapr-scheduler-server StatefulSet: %w", err)
-		}
+			if err != nil {
+				return fmt.Errorf("error getting dapr-scheduler-server StatefulSet: %w", err)
+			}
 
-		if sched.Spec.Replicas == nil {
-			return errors.New("dapr-scheduler-server StatefulSet has no replicas")
-		}
+			if sched.Spec.Replicas == nil {
+				return errors.New("dapr-scheduler-server StatefulSet has no replicas")
+			}
 
-		i.schedulerReplicaCount = int(*sched.Spec.Replicas)
-		break
+			i.schedulerReplicaCount = int(*sched.Spec.Replicas)
+			break
+		}
+	} else {
+		log.Info("Scheduler is disabled, skipping scheduler StatefulSet lookup")
+		i.schedulerReplicaCount = 0
 	}
 
 	if i.schedulerReplicaCount > 0 {


### PR DESCRIPTION
Upgrades from v1.0.0-ib to v1.16.6-ib based on upstream Dapr v1.16.6.

Changes
Helm: Added disableLeaderElection option for operator, added dapr_scheduler component
Injector: Backward compatibility for legacy com.infoblox.dapr.* annotations
CI/CD: Updated Jenkinsfile