### PR TITLE
feat: make root CA certificate TTL configurable

### DIFF
--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -185,6 +185,10 @@ spec:
 {{- end }}
         - "--trust-domain"
         - {{ .Values.global.mtls.controlPlaneTrustDomain }}
+{{- if .Values.global.mtls.caCertTTL }}
+        - "--ca-cert-ttl"
+        - "{{ .Values.global.mtls.caCertTTL }}"
+{{- end }}
 {{- with .Values.global.issuerFilenames }}
         - "--issuer-ca-filename"
         - "{{ .ca }}"

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -39,6 +39,8 @@ global:
     enabled: true
     workloadCertTTL: 24h
     allowedClockSkew: 15m
+    # Root CA and issuer certificate TTL. Default: 438000h (50 years).
+    caCertTTL: "438000h"
     controlPlaneTrustDomain: "cluster.local"
     # If set to true, a bound service account token will be mounted and used to
     # authenticate to Sentry.

--- a/cmd/sentry/app/app.go
+++ b/cmd/sentry/app/app.go
@@ -140,6 +140,11 @@ func Run() {
 	cfg.ListenAddress = opts.ListenAddress
 	cfg.Mode = modes.DaprMode(opts.Mode)
 
+	if opts.CACertTTL > 0 {
+		caCertTTL := opts.CACertTTL
+		cfg.CACertTTL = &caCertTTL
+	}
+
 	if opts.JWT.Issuer != nil {
 		cfg.JWT.Issuer = opts.JWT.Issuer
 	}

--- a/cmd/sentry/options/options.go
+++ b/cmd/sentry/options/options.go
@@ -45,6 +45,7 @@ type Options struct {
 	HealthzListenAddress  string
 	IssuerCredentialsPath string
 	TrustDomain           string
+	CACertTTL             time.Duration
 	Kubeconfig            string
 	Logger                logger.Options
 	Metrics               *metrics.FlagOptions
@@ -127,6 +128,7 @@ func New(origArgs []string) *Options {
 	fs.IntVar(&opts.HealthzPort, "healthz-port", 8080, "The port for the healthz server to listen on")
 	fs.StringVar(&opts.HealthzListenAddress, "healthz-listen-address", "", "The listening address for the healthz server")
 	fs.StringVar(&opts.Mode, "mode", string(modes.StandaloneMode), "Runtime mode for Dapr Sentry")
+	fs.DurationVar(&opts.CACertTTL, "ca-cert-ttl", 0, "Time-to-live for the root CA and issuer certificates (code default: 1 year). Set to 0 to use the default.")
 	fs.BoolVar(&opts.JWT.Enabled, "jwt-enabled", false, "Enable JWT token issuance by Sentry")
 	fs.StringVar(&opts.JWT.SigningKeyFilename, "jwt-key-filename", config.DefaultJWTSigningKeyFilename, "JWT signing key filename")
 	fs.StringVar(&opts.JWT.JWKSFilename, "jwks-filename", config.DefaultJWKSFilename, "JWKS (JSON Web Key Set) filename")

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -401,6 +401,7 @@ type MTLSSpec struct {
 	Enabled                 bool   `json:"enabled,omitempty"                 yaml:"enabled,omitempty"`
 	WorkloadCertTTL         string `json:"workloadCertTTL,omitempty"         yaml:"workloadCertTTL,omitempty"`
 	AllowedClockSkew        string `json:"allowedClockSkew,omitempty"        yaml:"allowedClockSkew,omitempty"`
+	CACertTTL               string `json:"caCertTTL,omitempty"               yaml:"caCertTTL,omitempty"`
 	SentryAddress           string `json:"sentryAddress,omitempty"           yaml:"sentryAddress,omitempty"`
 	ControlPlaneTrustDomain string `json:"controlPlaneTrustDomain,omitempty" yaml:"controlPlaneTrustDomain,omitempty"`
 	// Additional token validators to use.

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	CAStore          string
 	WorkloadCertTTL  time.Duration
 	AllowedClockSkew time.Duration
+	CACertTTL        *time.Duration
 	RootCertPath     string
 	IssuerCertPath   string
 	IssuerKeyPath    string
@@ -208,6 +209,15 @@ func parseConfiguration(conf Config, daprConfig *daprGlobalConfig.Configuration)
 		}
 
 		conf.AllowedClockSkew = d
+	}
+
+	if mtlsSpec != nil && mtlsSpec.CACertTTL != "" {
+		d, err := time.ParseDuration(mtlsSpec.CACertTTL)
+		if err != nil {
+			return conf, fmt.Errorf("error parsing CACertTTL duration: %w", err)
+		}
+
+		conf.CACertTTL = &d
 	}
 
 	if daprConfig.Spec.MTLSSpec != nil && len(daprConfig.Spec.MTLSSpec.ControlPlaneTrustDomain) > 0 {

--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -135,7 +135,7 @@ func New(ctx context.Context, conf config.Config) (Signer, error) {
 			X509RootKey:      x509RootKey,
 			TrustDomain:      conf.TrustDomain,
 			AllowedClockSkew: conf.AllowedClockSkew,
-			OverrideCATTL:    nil,
+			OverrideCATTL:    conf.CACertTTL,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate CA bundle: %w", err)


### PR DESCRIPTION
Add --ca-cert-ttl CLI flag, Helm caCertTTL value, and Dapr Configuration CRD support for configuring the root CA and issuer certificate TTL.

Changes:
- pkg/sentry/server/ca/bundle/cert.go: default remains 1 year (365d)
- pkg/sentry/server/ca/ca.go: pass config CACertTTL to bundle generation
- pkg/sentry/config/config.go: add CACertTTL field to Config struct
- pkg/config/configuration.go: add CACertTTL to MTLSSpec CRD
- cmd/sentry/options/options.go: add --ca-cert-ttl duration flag
- cmd/sentry/app/app.go: wire CLI flag to config
- charts/dapr/values.yaml: set default caCertTTL to 438000h (50 years)
- charts/dapr/charts/dapr_sentry/templates: pass --ca-cert-ttl arg

The code default is 1 year if no override is provided. Helm charts set 438000h (50 years) so deployed sentry will use 50-year CA certs.