### PR TITLE
chore: add Wiz security scan workflow

### DIFF
--- a/.github/workflows/wiz-security-scan.yaml
+++ b/.github/workflows/wiz-security-scan.yaml
@@ -1,0 +1,48 @@
+name: Wiz Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - master
+      - 'v*.*.*-ib'
+      - 'release/**'
+  push:
+    branches:
+      - main
+      - master
+      - 'v*.*.*-ib'
+      - 'release/**'
+
+concurrency:
+  group: wiz-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Job 1: Docker image scan via centralized reusable workflow
+  docker-scan:
+    name: Docker Image Scan
+    uses: Infoblox-CTO/.github/.github/workflows/wiz-security-scan-reusable.yaml@main
+    secrets:
+      GITPAT: ${{ secrets.GITPAT }}
+      WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+      WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
+      HARBOR_SERVICES_PROD_USERNAME: ${{ secrets.HARBOR_SERVICES_PROD_USERNAME }}
+      HARBOR_SERVICES_PROD_PASSWORD: ${{ secrets.HARBOR_SERVICES_PROD_PASSWORD }}
+    with:
+      dockerfile-path: 'docker/Dockerfile'
+      docker-context: './dist/linux_amd64/release'
+      docker-build-args: 'PKG_FILES=daprd'
+      pre-build-command: 'make dev-build-linux'
+
+  # Job 2: IaC + directory scan via centralized reusable workflow
+  iac-and-dir-scan:
+    name: IaC & Directory Scan
+    uses: Infoblox-CTO/.github/.github/workflows/wiz-iac-scan-reusable.yaml@main
+    secrets:
+      WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+      WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
+    with:
+      iac-types: 'Dockerfile,Kubernetes'


### PR DESCRIPTION
## Summary

- Adds Wiz security scan workflow mirroring the pattern from `atlas-onprem-platform-firewall`
- **Docker Image Scan**: builds using production `docker/Dockerfile` via `dev-docker-build` pattern (runs `make dev-build-linux` then scans built image)
- **IaC & Directory Scan**: scans Dockerfile and Kubernetes manifests

## Workflow details

| Property | Value |
|----------|-------|
| Dockerfile | `docker/Dockerfile` |
| Pre-build | `make dev-build-linux` (builds all dapr binaries to `./dist/linux_amd64/release/`) |
| Docker context | `./dist/linux_amd64/release` |
| Build arg | `PKG_FILES=daprd` |
| IaC types | `Dockerfile,Kubernetes` |
| Mode | AUDIT (findings reported, builds not blocked) |
| Triggers | PRs/pushes to `main`, `master`, `v*.*.*-ib`, `release/**` |

## Notes

- `dev-docker-build` in the `v1.16.0-ib` Makefile calls `dev-build-linux` (native Go build) + Docker build with context `./dist/linux_amd64/release`
- The `v1.16.0-ib` Dockerfile uses `COPY /$PKG_FILES /` (direct copy from context root, no `release/` subdirectory)

## Required secrets

Ensure these secrets are configured in `infobloxopen/dapr`:
- `GITPAT`
- `WIZ_CLIENT_ID` / `WIZ_CLIENT_SECRET`
- `HARBOR_SERVICES_PROD_USERNAME` / `HARBOR_SERVICES_PROD_PASSWORD`